### PR TITLE
fix: adiciona @Mapping para ignorar campo id no EnderecoMapper

### DIFF
--- a/src/main/java/com/sigesi/sigesi/enderecos/EnderecoMapper.java
+++ b/src/main/java/com/sigesi/sigesi/enderecos/EnderecoMapper.java
@@ -3,6 +3,7 @@ package com.sigesi.sigesi.enderecos;
 import java.util.List;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.NullValuePropertyMappingStrategy;
 
@@ -13,11 +14,13 @@ import com.sigesi.sigesi.enderecos.dtos.EnderecoUpdateDTO;
 @Mapper(componentModel = "spring", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface EnderecoMapper {
 
+  @Mapping(target = "id", ignore = true)
   Endereco toEntity(EnderecoCreateDTO dto);
 
   EnderecoResponseDTO toDto(Endereco entity);
 
   List<EnderecoResponseDTO> toDtoList(List<Endereco> entities);
 
+  @Mapping(target = "id", ignore = true)
   void updateFromDto(EnderecoUpdateDTO dto, @MappingTarget Endereco endereco);
 }


### PR DESCRIPTION
Corrige erro "Unmapped target property: id" do MapStruct adicionando anotações @Mapping(target = "id", ignore = true) nos métodos toEntity() e updateFromDto(). O campo id é gerado automaticamente pelo banco de dados e não deve ser mapeado a partir dos DTOs.

<img width="961" height="130" alt="image" src="https://github.com/user-attachments/assets/64506688-f288-4a47-b6f5-141ea060ff7a" />
