### PR TITLE
Fix/solicitacao

### DIFF
--- a/src/main/java/com/sigesi/sigesi/config/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/sigesi/sigesi/config/OAuth2LoginSuccessHandler.java
@@ -28,6 +28,6 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     usuarioService.processOAuthPostLogin(
         (org.springframework.security.oauth2.core.user.OAuth2User) authentication.getPrincipal());
 
-    response.sendRedirect("http://localhost:3000/");
+    response.sendRedirect("http://localhost:3000/portal");
   }
 }

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/Solicitacao.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/Solicitacao.java
@@ -5,6 +5,8 @@ import com.sigesi.sigesi.enderecos.Endereco;
 import com.sigesi.sigesi.usuarios.Usuario;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,9 +38,9 @@ public class Solicitacao {
   @Column(nullable = false)
   private LocalDate data;
 
-  @NotBlank(message = "Assunto é obrigatório")
-  @Column(nullable = false)
-  private String assunto;
+  @Enumerated(EnumType.STRING)
+  @Column(name = "assunto")
+  private SolicitacaoAssunto assunto;
 
   @NotBlank(message = "Corpo é obrigatório")
   @Column(nullable = false, columnDefinition = "TEXT")
@@ -57,6 +59,10 @@ public class Solicitacao {
   @ManyToOne
   @JoinColumn(name = "local_id", nullable = false)
   private Endereco local;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status")
+  private SolicitacaoStatus status;
 
   @PrePersist
   protected void onCreate() {

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoAssunto.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoAssunto.java
@@ -1,0 +1,9 @@
+package com.sigesi.sigesi.solicitacoes;
+
+public enum SolicitacaoAssunto {
+  BURACO,
+  ESGOTO,
+  ILUMINACAO,
+  LIMPEZA,
+  OUTROS
+}

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoMapper.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoMapper.java
@@ -15,8 +15,7 @@ import org.mapstruct.NullValuePropertyMappingStrategy;
 /**
  * Mapper para Solicitacao.
  */
-@Mapper(componentModel = "spring",
-    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+@Mapper(componentModel = "spring", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
 public interface SolicitacaoMapper {
 
   @Mapping(target = "id", ignore = true)
@@ -32,9 +31,12 @@ public interface SolicitacaoMapper {
 
   @Mapping(target = "id", ignore = true)
   @Mapping(target = "data", ignore = true)
-  @Mapping(target = "autor", source = "autorId")
-  @Mapping(target = "local", source = "localId")
-  @Mapping(target = "anexo", source = "anexoId")
+  @Mapping(target = "status", source = "status")
+  @Mapping(target = "local", ignore = true)
+  @Mapping(target = "anexo", ignore = true)
+  @Mapping(target = "assunto", ignore = true)
+  @Mapping(target = "body", ignore = true)
+  @Mapping(target = "autor", ignore = true)
   void updateFromDto(SolicitacaoUpdateDTO dto, @MappingTarget Solicitacao solicitacao);
 
   default Usuario mapAutor(Long autorId) {

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoService.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoService.java
@@ -2,10 +2,12 @@ package com.sigesi.sigesi.solicitacoes;
 
 import com.sigesi.sigesi.arquivos.ArquivoService;
 import com.sigesi.sigesi.config.NotFoundException;
+import com.sigesi.sigesi.enderecos.Endereco;
 import com.sigesi.sigesi.enderecos.EnderecoService;
 import com.sigesi.sigesi.solicitacoes.dtos.SolicitacaoCreateDTO;
 import com.sigesi.sigesi.solicitacoes.dtos.SolicitacaoResponseDTO;
 import com.sigesi.sigesi.solicitacoes.dtos.SolicitacaoUpdateDTO;
+import com.sigesi.sigesi.usuarios.Usuario;
 import com.sigesi.sigesi.usuarios.UsuarioService;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -46,27 +48,23 @@ public class SolicitacaoService {
   }
 
   public SolicitacaoResponseDTO createSolicitacao(SolicitacaoCreateDTO dto) {
-    usuarioService.getUsuarioById(dto.getAutorId());
-    enderecoService.getEnderecoEntityById(dto.getLocalId());
-
-    if (dto.getAnexoId() != null) {
-      arquivoService.getArquivoEntityById(dto.getAnexoId());
-    }
+    Usuario autor = usuarioService.getUsuarioById(dto.getAutorId());
+    Endereco local = enderecoService.getEnderecoEntityById(dto.getLocalId());
 
     Solicitacao entity = solicitacaoMapper.toEntity(dto);
+    entity.setAutor(autor);
+    entity.setLocal(local);
+
+    if (dto.getAnexoId() != null) {
+      entity.setAnexo(arquivoService.getArquivoEntityById(dto.getAnexoId()));
+    }
+
     Solicitacao saved = solicitacaoRepository.save(entity);
     return solicitacaoMapper.toDto(saved);
   }
 
   public SolicitacaoResponseDTO updateSolicitacao(Long id, SolicitacaoUpdateDTO dto) {
     Solicitacao solicitacao = this.getSolicitacaoEntityById(id);
-
-    usuarioService.getUsuarioById(dto.getAutorId());
-    enderecoService.getEnderecoEntityById(dto.getLocalId());
-
-    if (dto.getAnexoId() != null) {
-      arquivoService.getArquivoEntityById(dto.getAnexoId());
-    }
 
     solicitacaoMapper.updateFromDto(dto, solicitacao);
     Solicitacao updated = solicitacaoRepository.save(solicitacao);

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoService.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoService.java
@@ -54,6 +54,7 @@ public class SolicitacaoService {
     Solicitacao entity = solicitacaoMapper.toEntity(dto);
     entity.setAutor(autor);
     entity.setLocal(local);
+    entity.setStatus(SolicitacaoStatus.ABERTA);
 
     if (dto.getAnexoId() != null) {
       entity.setAnexo(arquivoService.getArquivoEntityById(dto.getAnexoId()));

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoStatus.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/SolicitacaoStatus.java
@@ -1,0 +1,9 @@
+package com.sigesi.sigesi.solicitacoes;
+
+public enum SolicitacaoStatus {
+  ABERTA,
+  EM_ANDAMENTO,
+  CONCLUIDA,
+  ENCERRADA,
+  REJEITADA
+}

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoCreateDTO.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoCreateDTO.java
@@ -1,5 +1,8 @@
 package com.sigesi.sigesi.solicitacoes.dtos;
 
+import com.sigesi.sigesi.solicitacoes.SolicitacaoAssunto;
+import com.sigesi.sigesi.solicitacoes.SolicitacaoStatus;
+
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -14,8 +17,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SolicitacaoCreateDTO {
 
-  @NotBlank(message = "Assunto é obrigatório")
-  private String assunto;
+  @NotNull(message = "Assunto é obrigatório")
+  private SolicitacaoAssunto assunto;
+
+  @NotNull(message = "Status é obrigatório")
+  private SolicitacaoStatus status;
 
   @NotBlank(message = "Corpo é obrigatório")
   private String body;

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoCreateDTO.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoCreateDTO.java
@@ -1,7 +1,6 @@
 package com.sigesi.sigesi.solicitacoes.dtos;
 
 import com.sigesi.sigesi.solicitacoes.SolicitacaoAssunto;
-import com.sigesi.sigesi.solicitacoes.SolicitacaoStatus;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -19,9 +18,6 @@ public class SolicitacaoCreateDTO {
 
   @NotNull(message = "Assunto é obrigatório")
   private SolicitacaoAssunto assunto;
-
-  @NotNull(message = "Status é obrigatório")
-  private SolicitacaoStatus status;
 
   @NotBlank(message = "Corpo é obrigatório")
   private String body;

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoResponseDTO.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoResponseDTO.java
@@ -2,6 +2,8 @@ package com.sigesi.sigesi.solicitacoes.dtos;
 
 import com.sigesi.sigesi.arquivos.dtos.ArquivoResponseDTO;
 import com.sigesi.sigesi.enderecos.Endereco;
+import com.sigesi.sigesi.solicitacoes.SolicitacaoAssunto;
+import com.sigesi.sigesi.solicitacoes.SolicitacaoStatus;
 import com.sigesi.sigesi.usuarios.Usuario;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -26,7 +28,10 @@ public class SolicitacaoResponseDTO {
   private LocalDate data;
 
   @NotBlank
-  private String assunto;
+  private SolicitacaoAssunto assunto;
+
+  @NotBlank
+  private SolicitacaoStatus status;
 
   @NotBlank
   private String body;

--- a/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoUpdateDTO.java
+++ b/src/main/java/com/sigesi/sigesi/solicitacoes/dtos/SolicitacaoUpdateDTO.java
@@ -1,7 +1,8 @@
 package com.sigesi.sigesi.solicitacoes.dtos;
 
+import com.sigesi.sigesi.solicitacoes.SolicitacaoStatus;
+
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -15,22 +16,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class SolicitacaoUpdateDTO {
 
-  @NotBlank(message = "Assunto não pode ser vazio")
-  @Schema(description = "Assunto da solicitação", example = "Solicitação de manutenção")
-  private String assunto;
+  @NotNull(message = "Status não pode ser vazio")
+  @Schema(description = "Status da solicitação", example = "ABERTO")
+  private SolicitacaoStatus status;
 
-  @NotBlank(message = "Corpo não pode ser vazio")
-  @Schema(description = "Descrição detalhada", example = "Detalhes da solicitação...")
-  private String body;
-
-  @Schema(description = "ID do arquivo anexo", example = "1")
-  private Long anexoId;
-
-  @NotNull(message = "Autor não pode ser nulo")
-  @Schema(description = "ID do usuário autor", example = "1")
-  private Long autorId;
-
-  @NotNull(message = "Local não pode ser nulo")
-  @Schema(description = "ID do endereço", example = "1")
-  private Long localId;
 }

--- a/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
+++ b/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
@@ -50,7 +50,7 @@ class SolicitacaoControllerTest {
   @MockitoBean
   private SolicitacaoService service;
 
-  private SolicitacaoResponseDTO responseDto(Long id, String assunto, String body) {
+  private SolicitacaoResponseDTO responseDto(Long id, SolicitacaoAssunto assunto, String body) {
     Usuario autor = Usuario.builder().id(1L).email("test@test.com").build();
     Endereco local = Endereco.builder().id(1L).logradouro("Rua Test").build();
 
@@ -67,21 +67,21 @@ class SolicitacaoControllerTest {
 
   private SolicitacaoCreateDTO createDto(String assunto, String body) {
     SolicitacaoCreateDTO dto = new SolicitacaoCreateDTO();
-    dto.setAssunto(assunto);
-    dto.setBody(body);
-    dto.setAnexoId(null);
-    dto.setAutorId(1L);
-    dto.setLocalId(1L);
+    // dto.setAssunto(assunto);
+    // dto.setBody(body);
+    // dto.setAnexoId(null);
+    // dto.setAutorId(1L);
+    // dto.setLocalId(1L);
     return dto;
   }
 
   private SolicitacaoUpdateDTO updateDto(String assunto, String body) {
     SolicitacaoUpdateDTO dto = new SolicitacaoUpdateDTO();
-    dto.setAssunto(assunto);
-    dto.setBody(body);
-    dto.setAnexoId(null);
-    dto.setAutorId(1L);
-    dto.setLocalId(1L);
+    // dto.setAssunto(assunto);
+    // dto.setBody(body);
+    // dto.setAnexoId(null);
+    // dto.setAutorId(1L);
+    // dto.setLocalId(1L);
     return dto;
   }
 
@@ -99,8 +99,8 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("GET /api/solicitacoes/ retorna 200 com múltiplas solicitações")
   void testListAllRetorna200ComMultiplasSolicitacoes() throws Exception {
-    SolicitacaoResponseDTO dto1 = responseDto(1L, "Assunto 1", "Corpo 1");
-    SolicitacaoResponseDTO dto2 = responseDto(2L, "Assunto 2", "Corpo 2");
+    SolicitacaoResponseDTO dto1 = responseDto(1L, SolicitacaoAssunto.BURACO, "Corpo 1");
+    SolicitacaoResponseDTO dto2 = responseDto(2L, SolicitacaoAssunto.ESGOTO, "Corpo 2");
 
     given(service.getAll()).willReturn(List.of(dto1, dto2));
 
@@ -109,15 +109,15 @@ class SolicitacaoControllerTest {
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$", hasSize(2)))
         .andExpect(jsonPath("$[0].id", is(1)))
-        .andExpect(jsonPath("$[0].assunto", is("Assunto 1")))
+        .andExpect(jsonPath("$[0].assunto", is(SolicitacaoAssunto.BURACO)))
         .andExpect(jsonPath("$[1].id", is(2)))
-        .andExpect(jsonPath("$[1].assunto", is("Assunto 2")));
+        .andExpect(jsonPath("$[1].assunto", is(SolicitacaoAssunto.ESGOTO)));
   }
 
   @Test
   @DisplayName("GET /api/solicitacoes/{id} retorna 200 com solicitação encontrada")
   void testGetByIdRetorna200QuandoEncontrada() throws Exception {
-    SolicitacaoResponseDTO dto = responseDto(1L, "Test Assunto", "Test Body");
+    SolicitacaoResponseDTO dto = responseDto(1L, SolicitacaoAssunto.ESGOTO, "Test Body");
 
     given(service.getSolicitacaoById(1L)).willReturn(dto);
 
@@ -125,7 +125,7 @@ class SolicitacaoControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is("Test Assunto")))
+        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.ESGOTO)))
         .andExpect(jsonPath("$.body", is("Test Body")));
   }
 
@@ -143,7 +143,7 @@ class SolicitacaoControllerTest {
   @DisplayName("POST /api/solicitacoes/ retorna 201 quando criada com sucesso")
   void testCreateRetorna201QuandoCriadaComSucesso() throws Exception {
     SolicitacaoCreateDTO createDto = createDto("Novo Assunto", "Novo Corpo");
-    SolicitacaoResponseDTO responseDto = responseDto(1L, "Novo Assunto", "Novo Corpo");
+    SolicitacaoResponseDTO responseDto = responseDto(1L, SolicitacaoAssunto.BURACO, "Novo Corpo");
 
     given(service.createSolicitacao(any(SolicitacaoCreateDTO.class))).willReturn(responseDto);
 
@@ -153,7 +153,7 @@ class SolicitacaoControllerTest {
         .andExpect(status().isCreated())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is("Novo Assunto")))
+        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.BURACO)))
         .andExpect(jsonPath("$.body", is("Novo Corpo")));
   }
 
@@ -183,8 +183,7 @@ class SolicitacaoControllerTest {
   @DisplayName("PATCH /api/solicitacoes/{id} retorna 200 com dados atualizados")
   void testUpdateRetorna200ComDadosAtualizados() throws Exception {
     SolicitacaoUpdateDTO updateDto = updateDto("Assunto Atualizado", "Corpo Atualizado");
-    SolicitacaoResponseDTO responseDto =
-        responseDto(1L, "Assunto Atualizado", "Corpo Atualizado");
+    SolicitacaoResponseDTO responseDto = responseDto(1L, SolicitacaoAssunto.BURACO, "Corpo Atualizado");
 
     given(service.updateSolicitacao(eq(1L), any(SolicitacaoUpdateDTO.class)))
         .willReturn(responseDto);
@@ -195,7 +194,7 @@ class SolicitacaoControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is("Assunto Atualizado")))
+        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.BURACO)))
         .andExpect(jsonPath("$.body", is("Corpo Atualizado")));
   }
 

--- a/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
+++ b/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
@@ -65,23 +65,18 @@ class SolicitacaoControllerTest {
         .build();
   }
 
-  private SolicitacaoCreateDTO createDto(String assunto, String body) {
+  private SolicitacaoCreateDTO createDto(SolicitacaoAssunto assunto, String body) {
     SolicitacaoCreateDTO dto = new SolicitacaoCreateDTO();
-    // dto.setAssunto(assunto);
-    // dto.setBody(body);
-    // dto.setAnexoId(null);
-    // dto.setAutorId(1L);
-    // dto.setLocalId(1L);
+    dto.setAssunto(assunto);
+    dto.setBody(body);
+    dto.setAnexoId(null);
+    dto.setAutorId(1L);
+    dto.setLocalId(1L);
     return dto;
   }
 
-  private SolicitacaoUpdateDTO updateDto(String assunto, String body) {
-    SolicitacaoUpdateDTO dto = new SolicitacaoUpdateDTO();
-    // dto.setAssunto(assunto);
-    // dto.setBody(body);
-    // dto.setAnexoId(null);
-    // dto.setAutorId(1L);
-    // dto.setLocalId(1L);
+  private SolicitacaoUpdateDTO updateDto(SolicitacaoStatus status) {
+    SolicitacaoUpdateDTO dto = new SolicitacaoUpdateDTO(status);
     return dto;
   }
 
@@ -142,7 +137,7 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("POST /api/solicitacoes/ retorna 201 quando criada com sucesso")
   void testCreateRetorna201QuandoCriadaComSucesso() throws Exception {
-    SolicitacaoCreateDTO createDto = createDto("Novo Assunto", "Novo Corpo");
+    SolicitacaoCreateDTO createDto = createDto(SolicitacaoAssunto.BURACO, "Novo Corpo");
     SolicitacaoResponseDTO responseDto = responseDto(1L, SolicitacaoAssunto.BURACO, "Novo Corpo");
 
     given(service.createSolicitacao(any(SolicitacaoCreateDTO.class))).willReturn(responseDto);
@@ -160,7 +155,7 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("POST /api/solicitacoes/ retorna 400 quando assunto está vazio")
   void testCreateRetorna400QuandoAssuntoVazio() throws Exception {
-    SolicitacaoCreateDTO createDto = createDto("", "Corpo válido");
+    SolicitacaoCreateDTO createDto = createDto(SolicitacaoAssunto.BURACO, "Corpo válido");
 
     mockMvc.perform(post("/api/solicitacoes/")
         .contentType(MediaType.APPLICATION_JSON)
@@ -171,7 +166,7 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("POST /api/solicitacoes/ retorna 400 quando body está vazio")
   void testCreateRetorna400QuandoBodyVazio() throws Exception {
-    SolicitacaoCreateDTO createDto = createDto("Assunto válido", "");
+    SolicitacaoCreateDTO createDto = createDto(SolicitacaoAssunto.BURACO, "");
 
     mockMvc.perform(post("/api/solicitacoes/")
         .contentType(MediaType.APPLICATION_JSON)
@@ -182,7 +177,7 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("PATCH /api/solicitacoes/{id} retorna 200 com dados atualizados")
   void testUpdateRetorna200ComDadosAtualizados() throws Exception {
-    SolicitacaoUpdateDTO updateDto = updateDto("Assunto Atualizado", "Corpo Atualizado");
+    SolicitacaoUpdateDTO updateDto = updateDto(SolicitacaoStatus.ABERTA);
     SolicitacaoResponseDTO responseDto = responseDto(1L, SolicitacaoAssunto.BURACO, "Corpo Atualizado");
 
     given(service.updateSolicitacao(eq(1L), any(SolicitacaoUpdateDTO.class)))
@@ -201,7 +196,7 @@ class SolicitacaoControllerTest {
   @Test
   @DisplayName("PATCH /api/solicitacoes/{id} retorna 404 quando recurso não existe")
   void testUpdateRetorna404QuandoRecursoNaoExiste() throws Exception {
-    SolicitacaoUpdateDTO updateDto = updateDto("Assunto", "Corpo");
+    SolicitacaoUpdateDTO updateDto = updateDto(SolicitacaoStatus.ABERTA);
 
     given(service.updateSolicitacao(eq(999L), any(SolicitacaoUpdateDTO.class)))
         .willThrow(new NotFoundException("Solicitação não encontrada com id 999"));

--- a/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
+++ b/src/test/java/com/sigesi/sigesi/solicitacoes/SolicitacaoControllerTest.java
@@ -104,9 +104,9 @@ class SolicitacaoControllerTest {
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$", hasSize(2)))
         .andExpect(jsonPath("$[0].id", is(1)))
-        .andExpect(jsonPath("$[0].assunto", is(SolicitacaoAssunto.BURACO)))
+        .andExpect(jsonPath("$[0].assunto", is("BURACO")))
         .andExpect(jsonPath("$[1].id", is(2)))
-        .andExpect(jsonPath("$[1].assunto", is(SolicitacaoAssunto.ESGOTO)));
+        .andExpect(jsonPath("$[1].assunto", is("ESGOTO")));
   }
 
   @Test
@@ -120,7 +120,7 @@ class SolicitacaoControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.ESGOTO)))
+        .andExpect(jsonPath("$.assunto", is("ESGOTO")))
         .andExpect(jsonPath("$.body", is("Test Body")));
   }
 
@@ -148,14 +148,14 @@ class SolicitacaoControllerTest {
         .andExpect(status().isCreated())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.BURACO)))
+        .andExpect(jsonPath("$.assunto", is("BURACO")))
         .andExpect(jsonPath("$.body", is("Novo Corpo")));
   }
 
   @Test
   @DisplayName("POST /api/solicitacoes/ retorna 400 quando assunto está vazio")
   void testCreateRetorna400QuandoAssuntoVazio() throws Exception {
-    SolicitacaoCreateDTO createDto = createDto(SolicitacaoAssunto.BURACO, "Corpo válido");
+    SolicitacaoCreateDTO createDto = createDto(null, "Corpo válido");
 
     mockMvc.perform(post("/api/solicitacoes/")
         .contentType(MediaType.APPLICATION_JSON)
@@ -189,7 +189,7 @@ class SolicitacaoControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.id", is(1)))
-        .andExpect(jsonPath("$.assunto", is(SolicitacaoAssunto.BURACO)))
+        .andExpect(jsonPath("$.assunto", is("BURACO")))
         .andExpect(jsonPath("$.body", is("Corpo Atualizado")));
   }
 


### PR DESCRIPTION
## ✨ O que foi feito

Este PR traz ajustes estruturais na entidade **Solicitação**, padronizando o uso de enums e reforçando as regras de negócio da API.

### Principais alterações
- Alterado o campo **`assunto`** da entidade `Solicitacao` para o tipo **enum**
- Ajustados **DTOs**, **mappers** e **testes** para refletir o novo tipo do campo `assunto`
- Adicionado o campo **`status`** na entidade `Solicitacao` como **enum**
- Ajustados **DTOs**, **validações** e **testes** para o novo campo `status`

---

## 🧠 Regras de negócio aplicadas

- Ao **criar uma solicitação**, o campo **`status`** é definido automaticamente como **`ABERTA`**
- O endpoint de **update de solicitação** permite **apenas a atualização do campo `status`**
  - Demais campos permanecem imutáveis após a criação

---

## 🧪 Testes

- Testes unitários e de controller foram ajustados para:
  - Validar o uso correto dos enums (`assunto` e `status`)

---