### PR TITLE
Feature/pipeline deploy

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,1 +1,0 @@
-name: Depoloy da aplicação

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,1 @@
+name: Depoloy da aplicação

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,24 +7,55 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  build-and-lint:
+  ci:
+    name: CI - Build, Lint e Testes
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v5
+      - name: Checkout repository
+        uses: actions/checkout@v5
 
-    - name: Set up JDK 21
-      uses: actions/setup-java@v5
-      with:
-        distribution: temurin
-        java-version: '21'
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
 
-    - name: Build project
-      run: mvn clean compile
+      - name: Build project
+        run: mvn clean compile
 
-    - name: Lint with Checkstyle
-      run: mvn checkstyle:check
+      - name: Lint with Checkstyle
+        run: mvn checkstyle:check
 
-    - name: Run tests
-      run: mvn test
+      - name: Run tests
+        run: mvn test
+
+  cd:
+    name: CD - Docker Build & Push
+    runs-on: ubuntu-latest
+
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
+    needs: ci
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Login no Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/sigesi-backend:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/sigesi-backend:${{ github.sha }}
+
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,9 +33,7 @@ jobs:
   cd:
     name: CD - Docker Build & Push
     runs-on: ubuntu-latest
-
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
     needs: ci
 
     steps:
@@ -56,6 +54,3 @@ jobs:
           tags: |
             ${{ secrets.DOCKERHUB_USERNAME }}/sigesi-backend:latest
             ${{ secrets.DOCKERHUB_USERNAME }}/sigesi-backend:${{ github.sha }}
-
-
-


### PR DESCRIPTION
# Adiciona envio da imagem Docker para o Docker Hub na pipeline

## O que foi feito

Este PR atualiza a pipeline do GitHub Actions para que, após o merge na branch `main`, seja realizado o **build da imagem Docker** e o **push para o Docker Hub**.

- Mantido:
  - Build do projeto (`mvn clean compile`)
  - Lint com Checkstyle
  - Execução de testes
- Adicionado:
  - Job de CD (`docker build` e `docker push`)
  - Condicional para que o Docker seja construído **somente em push para `main`**
  - Uso de secrets `DOCKERHUB_USERNAME` e `DOCKERHUB_TOKEN` para autenticação segura