### PR TITLE
fix: corrige não login de usuario inativo

### DIFF
--- a/src/main/java/com/sigesi/sigesi/authentication/CustomOidcUserService.java
+++ b/src/main/java/com/sigesi/sigesi/authentication/CustomOidcUserService.java
@@ -17,10 +17,17 @@ public class CustomOidcUserService extends OidcUserService {
   private UsuarioService usuarioService;
 
   @Override
-  public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+  public OidcUser loadUser(OidcUserRequest userRequest)
+      throws OAuth2AuthenticationException {
+
     OidcUser oidcUser = super.loadUser(userRequest);
 
     Usuario user = usuarioService.processOAuthPostLogin(oidcUser);
+
+    if (!user.getAtivo()) {
+      throw new OAuth2AuthenticationException(
+          "Usuário inativo. Aguardando liberação.");
+    }
 
     return new CustomOAuth2User(oidcUser, user);
   }

--- a/src/main/java/com/sigesi/sigesi/config/SpringConfig.java
+++ b/src/main/java/com/sigesi/sigesi/config/SpringConfig.java
@@ -33,7 +33,11 @@ public class SpringConfig {
             .anyRequest().authenticated())
         .oauth2Login(oauth2 -> oauth2
             .userInfoEndpoint(userInfo -> userInfo.oidcUserService(customOidcUserService))
-            .successHandler(successHandler));
+            .successHandler(successHandler)
+            .failureHandler((request, response, exception) -> {
+              response.sendRedirect(
+                  "http://localhost:3000/?authError=usuario_inativo");
+            }));
 
     return http.build();
   }


### PR DESCRIPTION
## 🔐 Correção do fluxo de login para usuários inativos com redirecionamento

### 📌 Descrição
Este PR ajusta o fluxo de autenticação via **OAuth2/OIDC** para tratar corretamente usuários com o campo `ativo = false`.

O objetivo é impedir o acesso de usuários inativos **sem quebrar o fluxo de login**, garantindo que a falha de autenticação resulte em um **redirecionamento controlado para o frontend**.

---

### ✨ O que foi feito

#### ✔️ Tratamento de usuário inativo
- Ajustado o `CustomOidcUserService` para:
  - Permitir o **primeiro login** de usuários recém-criados
  - Bloquear logins subsequentes quando `ativo = false`
  - Lançar `OAuth2AuthenticationException` em caso de usuário inativo

#### ✔️ Redirecionamento em caso de falha
- Configurado `failureHandler` no `oauth2Login`
- Em qualquer erro de autenticação (usuário inativo, falha no OAuth, etc.), o usuário é redirecionado para:
http://localhost:3000/?authError=usuario_inativo