### PR TITLE
Fix/admin toggle

### DIFF
--- a/src/main/java/com/sigesi/sigesi/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/sigesi/sigesi/config/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.server.ResponseStatusException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -71,6 +72,15 @@ public class GlobalExceptionHandler {
             "status", HttpStatus.PAYLOAD_TOO_LARGE.value(),
             "error", "File Too Large",
             "message", "File size exceeds maximum allowed size"));
+  }
+
+  @ExceptionHandler(ResponseStatusException.class)
+  public ResponseEntity<Map<String, Object>> handleResponseStatus(ResponseStatusException ex) {
+    return ResponseEntity.status(ex.getStatusCode())
+        .body(Map.of(
+            "status", ex.getStatusCode().value(),
+            "error", ex.getStatusCode().toString(),
+            "message", ex.getReason()));
   }
 
   @ExceptionHandler(RuntimeException.class)

--- a/src/main/java/com/sigesi/sigesi/usuarios/UsuarioRepository.java
+++ b/src/main/java/com/sigesi/sigesi/usuarios/UsuarioRepository.java
@@ -1,5 +1,6 @@
 package com.sigesi.sigesi.usuarios;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
   Optional<Usuario> findByEmail(String email);
+
+  List<Usuario> findByIdNot(Long id);
 }

--- a/src/main/java/com/sigesi/sigesi/usuarios/UsuarioService.java
+++ b/src/main/java/com/sigesi/sigesi/usuarios/UsuarioService.java
@@ -7,8 +7,10 @@ import com.sigesi.sigesi.usuarios.enums.Role;
 import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class UsuarioService {
@@ -19,8 +21,16 @@ public class UsuarioService {
   @Autowired
   private UsuarioMapper usuarioMapper;
 
+  private void validarUsuarioEditavel(Long id) {
+    if (id == 1) {
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN,
+          "Não é permitido realizar essa ação para este usuário");
+    }
+  }
+
   public List<Usuario> getAll() {
-    return usuarioRepository.findAll();
+    return usuarioRepository.findByIdNot(1L);
   }
 
   public Usuario getUsuarioById(Long id) {
@@ -29,12 +39,16 @@ public class UsuarioService {
   }
 
   public Usuario toggleUsuarioAtivo(Long id) {
+    validarUsuarioEditavel(id);
+
     Usuario usuario = this.getUsuarioById(id);
     usuario.setAtivo(!usuario.getAtivo());
     return usuarioRepository.save(usuario);
   }
 
   public Usuario updateUsuario(Long id, UsuarioUpdateDTO usuarioUpdateDTO) {
+    validarUsuarioEditavel(id);
+
     Usuario usuario = this.getUsuarioById(id);
 
     usuarioMapper.updateFromDto(usuarioUpdateDTO, usuario);

--- a/src/test/java/com/sigesi/sigesi/usuarios/UsuarioServiceTest.java
+++ b/src/test/java/com/sigesi/sigesi/usuarios/UsuarioServiceTest.java
@@ -5,7 +5,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,30 +44,33 @@ class UsuarioServiceTest {
   }
 
   @Test
-  @DisplayName("Deve retornar lista vazia quando não há usuários")
+  @DisplayName("Deve retornar lista vazia quando não há usuários (exceto root)")
   void testGetAllRetornaListaVazia() {
-    when(usuarioRepository.findAll()).thenReturn(List.of());
+    when(usuarioRepository.findByIdNot(1L)).thenReturn(List.of());
 
     List<Usuario> resultado = usuarioService.getAll();
 
     assertNotNull(resultado);
     assertTrue(resultado.isEmpty());
-    verify(usuarioRepository, times(1)).findAll();
+
+    verify(usuarioRepository, times(1)).findByIdNot(1L);
   }
 
   @Test
-  @DisplayName("Deve retornar lista com usuários existentes")
+  @DisplayName("Deve retornar lista com usuários existentes (exceto usuário root)")
   void testGetAllRetornaListaComUsuarios() {
     Usuario u1 = mock(Usuario.class);
     Usuario u2 = mock(Usuario.class);
     Usuario u3 = mock(Usuario.class);
 
-    when(usuarioRepository.findAll()).thenReturn(Arrays.asList(u1, u2, u3));
+    when(usuarioRepository.findByIdNot(1L))
+        .thenReturn(List.of(u1, u2, u3));
 
     List<Usuario> resultado = usuarioService.getAll();
 
     assertEquals(3, resultado.size());
-    verify(usuarioRepository, times(1)).findAll();
+    assertEquals(List.of(u1, u2, u3), resultado);
+    verify(usuarioRepository, times(1)).findByIdNot(1L);
   }
 
   @Test
@@ -99,10 +101,10 @@ class UsuarioServiceTest {
   @Test
   @DisplayName("Deve alternar status ativo de usuário ativo para inativo")
   void testToggleUsuarioAtivoDeAtivoParaInativo() {
-    when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioMock));
+    when(usuarioRepository.findById(2L)).thenReturn(Optional.of(usuarioMock));
     when(usuarioRepository.save(any(Usuario.class))).thenReturn(usuarioMock);
 
-    Usuario resultado = usuarioService.toggleUsuarioAtivo(1L);
+    Usuario resultado = usuarioService.toggleUsuarioAtivo(2L);
 
     assertNotNull(resultado);
     verify(usuarioRepository, times(1)).save(usuarioMock);
@@ -112,10 +114,10 @@ class UsuarioServiceTest {
   @DisplayName("Deve alternar status ativo de usuário inativo para ativo")
   void testToggleUsuarioAtivoDeInativoParaAtivo() {
     usuarioMock.setAtivo(false);
-    when(usuarioRepository.findById(1L)).thenReturn(Optional.of(usuarioMock));
+    when(usuarioRepository.findById(2L)).thenReturn(Optional.of(usuarioMock));
     when(usuarioRepository.save(any(Usuario.class))).thenReturn(usuarioMock);
 
-    Usuario resultado = usuarioService.toggleUsuarioAtivo(1L);
+    Usuario resultado = usuarioService.toggleUsuarioAtivo(2L);
 
     assertNotNull(resultado);
     verify(usuarioRepository, times(1)).save(usuarioMock);


### PR DESCRIPTION
## 🛡️ Tratamento de erros Forbidden e proteção do usuário root

### O que foi feito
- Adicionado handler específico para erros **403 (Forbidden)** no `GlobalExceptionHandler`, garantindo que exceções de autorização retornem o status HTTP correto.
- Criada regra de negócio para **proteger o usuário de ID = 1 (usuário root)**, impedindo:
  - Listagem do usuário root nas consultas gerais
  - Desativação do usuário
  - Alteração de role ou dados sensíveis